### PR TITLE
Add custom pageview property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ Add Plausible Analytics to the root layout to track page views.
 <slot />
 ```
 
+Add custom properties to page views:
+
+```svelte
+<script>
+  import { PlausibleAnalytics } from '@accuser/svelte-plausible-analytics';
+</script>
+
+<PlausibleAnalytics pageviewprops={{"fancy-hyphenated-prop": "fancy value string", somekindofboolean: false}} />
+
+<slot />
+```
+
+*Note*: as per the Plausible documentation, up to 30 custom properties can be included alongside a pageview by adding multiple attributes.
+
+Set custom properties in the `pageviewprops` Svelte prop on the `<PlausibleAnalytics />` component. 
+
+The Plausible-required `event-` prefix can be omitted. Eg. `<PlausibleAnalytics pageviewprops={{"my-fancy-prop": "a value"}} />` becomes `<script src="https://plausible.io/js/script.pageview-props.js" event-my-fancy-prop"="a value"></script>`.
+
 Track analytics events:
 
 ```svelte

--- a/src/lib/PlausibleAnalytics.svelte
+++ b/src/lib/PlausibleAnalytics.svelte
@@ -85,6 +85,14 @@
 	 */
 	export let outboundLinks = false;
 
+	/**
+	 * Add custom properties to pageviews.
+	 * This is a standard single-level object with {"name" | name: "string" | boolean}.
+	 * (See Plausible's documentation for dashboard configuration details.)
+	 * @defaultValue `Object`
+	 */
+	export let pageviewprops = {};
+
 	$: api = `${apiHost}/api/event`;
 	$: src = [
 		`${apiHost}/js/script`,
@@ -93,15 +101,31 @@
 		hash ? 'hash' : undefined,
 		local ? 'local' : undefined,
 		outboundLinks ? 'outbound-links' : undefined,
+		pageviewprops ? 'pageview-props' : undefined,
 		'js'
 	]
 		.filter(Boolean)
 		.join('.');
+
+	function setPageviewProps(node) {
+		if (pageviewprops === undefined) return false;
+		Object.keys(pageviewprops).length
+			? Object.entries(pageviewprops).map((prop, i) => {
+					node.setAttribute(`event-${prop[0]}`, prop[1]);
+			  })
+			: false;
+	}
 </script>
 
 <svelte:head>
 	{#if enabled}
-		<script data-api={api} data-domain={domain.toString()} defer {src}></script>
+		<script
+			data-api={api}
+			data-domain={domain.toString()}
+			defer
+			{src}
+			use:setPageviewProps
+		></script>
 		<script>
 			window.plausible =
 				window.plausible ||


### PR DESCRIPTION
I had the idea to implement [custom pageview properties](https://plausible.io/docs/custom-pageview-props#3-filter-your-dashboard-by-custom-properties) on a navigation/routing system for a personal project. This change adds:

1. Load the specific subset of Plausible `script` via `<PlausibleAnalytics />` prop
2. `setAttribute`s on the `<script>` tag via `pageviewprops={{"some-tracking-key": "some value"}}` and [Svelte's `use` action](https://css-tricks.com/using-custom-elements-in-svelte/#aa-using-a-svelte-action-to-force-setting-attributes).

Happy to discuss a better implementation! Cheers.

Submitted to the upstream repo in PR [#10](https://github.com/accuser/svelte-plausible-analytics/pull/10).